### PR TITLE
Add Vercel Analytics integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/sitemap": "^3.4.1",
         "@astrojs/vercel": "^8.2.3",
         "@splidejs/splide": "^4.1.4",
+        "@vercel/analytics": "^1.5.0",
         "astro": "^5.12.1",
         "astro-robots-txt": "^1.0.0",
         "graphql-request": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@astrojs/sitemap": "^3.4.1",
     "@astrojs/vercel": "^8.2.3",
     "@splidejs/splide": "^4.1.4",
+    "@vercel/analytics": "^1.5.0",
     "astro": "^5.12.1",
     "astro-robots-txt": "^1.0.0",
     "graphql-request": "^7.2.0"

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import "@splidejs/splide/css";
 import "@splidejs/splide/css/core";
+import Analytics from '@vercel/analytics/astro'
 
 interface Props {
   title?: string;
@@ -64,6 +65,7 @@ const {
     <script
       src="https://unpkg.com/@lottiefiles/lottie-player@0.3.0/dist/lottie-player.js"
     ></script>
+    <Analytics/>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
Installed @vercel/analytics package and integrated its component into the base Astro layout to enable analytics tracking across the site.